### PR TITLE
Fix path typo in clientScript.js

### DIFF
--- a/public/clientScript.js
+++ b/public/clientScript.js
@@ -37,6 +37,6 @@ function transferFailed(evt) {
 var oReq = new XMLHttpRequest();
 oReq.addEventListener("load", reqListener);
 oReq.addEventListener("error", transferFailed);
-oReq.open("GET", "/embed/item/1");
+oReq.open("GET", "/embed/items/1");
 oReq.setRequestHeader('authToken', 'importAuthTokenExample-239842alvanv98arkfjsd9a8hb')
 oReq.send();


### PR DESCRIPTION
This fixes a typo in the path when embedding an item using the XHR method. The correct path is `/embed/items/:id`, where `items` is plural.

Steps to reproduce the issue:

- Create a `.env` file including the line `USE_XHR=true`
- Login as any user. Note that the request to `localhost:3001/embed/item/1` fails with a 404 response, and the embedded card fails to load.