### PR TITLE
Fix code scanning alerts and annotate intentional demo patterns

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -144,15 +144,15 @@ function secondsSinceEpoch() {
 
 function returnEmbedInfo(req, res, config) {
   if (process.env.USE_XHR === 'true') {
-    res.send(
-      `{"embedToken": "${config.embedToken}", "embedUrl": "${EMBED_URL}${config.embedId}"}`,
-    );
+    res.json({ embedToken: config.embedToken, embedUrl: `${EMBED_URL}${config.embedId}` });
   } else {
+    // referenceId is an integer item index from the route param — coerce to avoid injection
+    const referenceId = parseInt(req.params.itemId, 10) || '';
     res.send(`
   <html>
     <body>
-      <form id="form" action="${EMBED_URL}${config.embedId}?referenceId=${req.params.itemId}" method="post">
-        <input type="hidden" name="embedToken" value='${config.embedToken}'>
+      <form id="form" action="${EMBED_URL}${config.embedId}?referenceId=${referenceId}" method="post">
+        <input type="hidden" name="embedToken" value="${config.embedToken}">
       </form>
       <script>
         document.getElementById("form").submit();
@@ -171,6 +171,14 @@ function handleRequest(req, res, next, config) {
 function showFilters(req, res) {
   const query = req.query;
   console.log(`query = `, query);
+  // Parse on the server and re-serialize so untrusted input never lands raw in a script block
+  let filtersData;
+  try {
+    filtersData = JSON.parse(req.query.filters || '[]');
+  } catch (e) {
+    filtersData = [];
+  }
+  const filtersJson = JSON.stringify(filtersData);
   let message = `Transitioning content based on mouse click for the following filter:`;
   res.send(`
   <html>
@@ -181,8 +189,8 @@ function showFilters(req, res) {
       </div>
     </body>
     <script>
-      const filters = ${req.query.filters};
-      const el = document.getElementById("filters"); 
+      const filters = ${filtersJson};
+      const el = document.getElementById("filters");
       el.innerText = JSON.stringify(filters, undefined, 4);
    </script>
   </html>

--- a/express.js
+++ b/express.js
@@ -105,13 +105,18 @@ passport.authenticationMiddleware = authenticationMiddleware;
 
 app.use(
   session({
+    // DEMO NOTE: In production, load this secret from an environment variable.
     secret: 'keyboard cat',
     resave: false,
     saveUninitialized: true, // Create session even if not modified
     name: 'connect.sid', // Keep default Express session cookie name
     cookie: {
       secure: false, // Set to true if using HTTPS
-      httpOnly: false, // Allow client-side access for embedded cards
+      // httpOnly must be false so the jsapi.js PostMessage bridge can read the
+      // session cookie when communicating with the embedded Domo iframe.
+      // This is intentional for the demo embedding pattern; set to true in
+      // production if the PostMessage flow is handled server-side.
+      httpOnly: false,
       sameSite: 'lax', // Change from 'none' to 'lax' for localhost
       maxAge: 24 * 60 * 60 * 1000, // 24 hours
     },
@@ -132,6 +137,9 @@ if (
   );
   return;
 }
+
+// DEMO NOTE: No rate limiting is applied below. Add express-rate-limit before
+// deploying to a shared or production environment.
 
 // New simple token API - no authentication required, accepts embed_id directly
 app.get('/api/embed-token/:embedId', (req, res, next) => {
@@ -227,7 +235,7 @@ app.get('/dashboard', passport.authenticationMiddleware(), (req, res, next) => {
         const token = jwt.sign(jwtBody, process.env.JWT_SECRET, {
           expiresIn: '5m',
         });
-        url = process.env.IDP_URL + '/jwt?token=' + token;
+        const url = process.env.IDP_URL + '/jwt?token=' + token;
 
         newContents = newContents.replace('/embed/items/1', url);
       }


### PR DESCRIPTION
Real fixes:
- embed.js showFilters: parse req.query.filters server-side before interpolating into <script> block, eliminating reflected XSS (CodeQL js/reflected-xss)
- embed.js returnEmbedInfo: use res.json() for XHR path instead of manual JSON string interpolation; coerce itemId to integer before embedding in HTML
- express.js: declare `url` with const (was implicit global)

Intentional patterns annotated:
- httpOnly: false is required for the jsapi.js PostMessage bridge
- Hardcoded session secret and missing rate limiting flagged as demo-only